### PR TITLE
Fix RSS feed parsing for multiline summariesfix: robust CSV parsing for multiline fields; validate & sanitize lin…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "csv-parse": "^6.1.0",
         "csv-parser": "^3.2.0",
         "follow-redirects": "^1.15.11"
+      },
+      "devDependencies": {
+        "fast-xml-parser": "^5.2.5"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
+      "license": "MIT"
     },
     "node_modules/csv-parser": {
       "version": "3.2.0",
@@ -23,6 +33,25 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/follow-redirects": {
@@ -44,6 +73,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "csv-parse": "^6.1.0",
     "csv-parser": "^3.2.0",
     "follow-redirects": "^1.15.11"
   },
@@ -20,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/latamprompt/Online-Feed/issues"
   },
-  "homepage": "https://github.com/latamprompt/Online-Feed#readme"
+  "homepage": "https://github.com/latamprompt/Online-Feed#readme",
+  "devDependencies": {
+    "fast-xml-parser": "^5.2.5"
+  }
 }


### PR DESCRIPTION
**Root cause:** Old CSV parser split on raw \n, breaking quoted multiline summaries into separate rows. This caused column misalignment, invalid <link>/<guid>, and phantom feed items in Feedly/Outlook.

**Fix:** 
- Switched to csv-parse with multiline support.
- Added row validation & URL sanitizing.
- Stripped newlines from <link> and <guid>.
- Preserved summaries with CDATA.
- Optional XML validation in dev (--validate-xml).
